### PR TITLE
[codex] Fix team lookup on problem pages during SSR

### DIFF
--- a/webapp/pages/problems/[id].vue
+++ b/webapp/pages/problems/[id].vue
@@ -394,7 +394,11 @@ const {
   `user-teams-${user.value?.id}`,
   async () => {
     try {
-      const response = await $fetch("/api/teams");
+      // During SSR, forward browser cookies so the protected teams API can identify the user.
+      const authFetch = import.meta.server ? useRequestFetch() : $fetch;
+      const response = await authFetch("/api/teams", {
+        credentials: "include",
+      });
       return response.teams || [];
     } catch (err) {
       console.error("获取用户团队列表失败:", err);


### PR DESCRIPTION
## What changed

This fixes the problem detail page team lookup during server-side rendering.

The page is protected by auth middleware, but its `useAsyncData` callback fetched `/api/teams` with plain `$fetch`. During SSR that internal request does not forward the browser cookies, so a logged-in user could render the page as if they had no registered teams until client-side hydration refreshed the state.

The fix uses `useRequestFetch()` on the server to forward the incoming request context, while preserving `$fetch` on the client.

## Validation

- `git diff --check` passed.
- `nuxi typecheck` was attempted through `webapp/node_modules/.bin/nuxi.cmd typecheck`, but the current upstream baseline fails with existing type errors and missing declarations unrelated to this one-file change.